### PR TITLE
Temperature in C not F.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:3f53e9e4dfbb664cd62940c9c4b65a2171c66acd0b7621a1a6b8e78513525a52"
+  digest = "1:69b1cc331fca23d702bd72f860c6a647afd0aa9fcbc1d0659b1365e26546dd70"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
-  version = "v1.1.1"
+  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:7f769a7ea697a8e50c8a79a829f53a469e3ca7b8e314434ea9d9a25ca8401cb7"
@@ -105,7 +105,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c36519504a884f2e4c5e72bece6f455b187abd956144d82a1b2b579a68b8ddc5"
+  digest = "1:a414df669aebcd6d504a39ed564f85f64659973ee136849990938b770672a727"
   name = "github.com/vapor-ware/synse-sdk"
   packages = [
     "sdk",
@@ -114,7 +114,7 @@
     "sdk/policies",
   ]
   pruneopts = "UT"
-  revision = "27f996297fa256ea1d57241c8d8ce684640c0b31"
+  revision = "ee3e84f602c74c6e499a36f7f58916f08eeb74b6"
 
 [[projects]]
   digest = "1:a95be5a656edf57b48a06335bbb627fc2eb5f37890df1183bbaab9443c43cae1"
@@ -130,11 +130,11 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "4d3f4d9ffa16a13f451c3b2999e9c49e9750bf06"
+  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
 
 [[projects]]
   branch = "master"
-  digest = "1:d7bb1ec1da715f83d407bd8a0fd92810bc8e36577286350d61b6fd62f9244236"
+  digest = "1:6ca51c5d8a610b3da56856df7a8f8f3e075eba8d5f7a4acbadd79b2d2a368054"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -146,18 +146,18 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "c44066c5c816ec500d459a2a324a753f78531ae0"
+  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
 
 [[projects]]
   branch = "master"
-  digest = "1:d3e0b1b48b36298893e7667f91bce04d1b6996e5eb93b898db926cad94ce9514"
+  digest = "1:48b757e61d662021f49a6a0afc67dacae27ee0c3a8f858d927126bcdf49222d3"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "7e31e0c00fa05cb5fbf4347b585621d6709e19a4"
+  revision = "ec83556a53fe16b65c452a104ea9d1e86a671852"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -184,11 +184,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
   branch = "master"
@@ -196,7 +196,7 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "b69ba1387ce2108ac9bc8e8e5e5a46e7d5c72313"
+  revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
 
 [[projects]]
   digest = "1:c3ad9841823db6da420a5625b367913b4ff54bbe60e8e3c98bd20e243e62e2d2"

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -69,16 +69,16 @@ var (
 		},
 	}
 
-	// TemperatureFTenths is the output type for temperature readings in tenths (multiply raw reading by .1)"
-	TemperatureFTenths = sdk.OutputType{
-		Name:          "temperatureFTenths",
+	// Temperature is the output type for temperature readings.
+	Temperature = sdk.OutputType{
+		Name:          "temperature",
 		Precision:     3,
 		ScalingFactor: ".1", // Raw reading for VEM PLC is tenths of degrees F.
 		Unit: sdk.Unit{
-			Name:   "fahrenheit",
-			Symbol: "F",
+			Name:   "celsius",
+			Symbol: "C",
 		},
-		Conversion: "englishToMetricTemperature",
+		Conversion: "englishToMetricTemperature", // Farenheit to Celsius.
 	}
 
 	// FlowGpm is the output type for flow readings in gallons per minute. FUTURE: Metric / English.

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -19,7 +19,7 @@ func MakePlugin() *sdk.Plugin {
 		&outputs.Frequency,
 		&outputs.SItoKWhPower,
 		&outputs.FanSpeedPercent,
-		&outputs.TemperatureFTenths,
+		&outputs.Temperature,
 		&outputs.FlowGpm,
 		&outputs.FlowGpmTenths,
 		&outputs.Coil,


### PR DESCRIPTION
This change fixes up the temperature units on the VEM now that the sdk is updated.

```vapor@basx-vec1:~$ # Return Air Temperature
vapor@basx-vec1:~$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/501c707c6ac04a6126172b28bdc417c3
{
  "kind":"vem-plc.return.air.temperature",
  "data":[
    {
      "value":24.111,
      "timestamp":"2018-11-19T22:39:00.794949728Z",
      "unit":{
        "symbol":"C",
        "name":"celsius"
      },
      "type":"temperature",
      "info":"Return Air Temperature"
    }
  ]
}```