### PR TITLE
Add Modbus writes. Cleanup reads.

### DIFF
--- a/pkg/devices/coils.go
+++ b/pkg/devices/coils.go
@@ -1,34 +1,34 @@
 package devices
 
 import (
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/mitchellh/mapstructure"
 	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/config"
-	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/utils"
 	"github.com/vapor-ware/synse-sdk/sdk"
 )
 
 // CoilsHandler is a handler that should be used for all devices/outputs
 // that read from/write to coils.
 var CoilsHandler = sdk.DeviceHandler{
-	Name: "coil",
-	Read: readCoils,
+	Name:  "coil",
+	Read:  readCoils,
+	Write: writeCoils,
 }
 
-// readCoil is the read function for the coils device handler.
+// readCoils is the read function for the coils device handler.
 func readCoils(device *sdk.Device) ([]*sdk.Reading, error) {
-	var deviceData config.ModbusDeviceData
-	err := mapstructure.Decode(device.Data, &deviceData)
+	if device == nil {
+		return nil, fmt.Errorf("readCoils device is nil")
+	}
+
+	modbusConfig, client, err := GetModbusClientAndConfig(device)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := utils.NewClient(&deviceData)
-	if err != nil {
-		return nil, err
-	}
-
-	failOnErr := deviceData.FailOnError
+	failOnErr := (*modbusConfig).FailOnError
 	log.Debugf("fail on error: %v", failOnErr)
 
 	// For each device instance, we will have various outputs defined.
@@ -51,7 +51,7 @@ func readCoils(device *sdk.Device) ([]*sdk.Reading, error) {
 		}
 
 		// Use the output data config to get the coils reading
-		results, err := client.ReadCoils(uint16(outputData.Address), uint16(outputData.Width))
+		results, err := (*client).ReadCoils(uint16(outputData.Address), uint16(outputData.Width))
 		if err != nil {
 			if failOnErr {
 				return nil, err
@@ -60,25 +60,58 @@ func readCoils(device *sdk.Device) ([]*sdk.Reading, error) {
 			continue
 		}
 
-		// Cast the raw reading value to the specified output type
-		data, err := utils.CastToType(outputData.Type, results)
+		reading, err := UnpackReading(output, outputData.Type, results, failOnErr)
 		if err != nil {
-			if failOnErr {
-				return nil, err
-			}
-			log.Errorf("error casting reading data: %v", err)
-			continue
-		}
-		log.Debugf("coils read result: %v", data)
-
-		reading, err := output.MakeReading(data)
-		if err != nil {
-			// In this case we will not check the 'failOnError' flag because
-			// this isn't an issue with reading the device, its a configuration
-			// issue and the error should be noted.
 			return nil, err
 		}
 		readings = append(readings, reading)
 	}
 	return readings, nil
+}
+
+// writeCoils is the read function for the coils device handler.
+func writeCoils(device *sdk.Device, data *sdk.WriteData) (err error) {
+
+	if device == nil {
+		return fmt.Errorf("device is nil")
+	}
+	if data == nil {
+		return fmt.Errorf("data is nil")
+	}
+
+	_, client, err := GetModbusClientAndConfig(device)
+	if err != nil {
+		return err
+	}
+
+	// Pull out the data to send on the wire from data.Data.
+	modbusData := data.Data
+
+	output, err := GetOutput(device)
+	if err != nil {
+		return err
+	}
+
+	// Translate the data. For whatever reason, the modbus interface wants 0
+	// for false and FF00 for true.
+	dataString := string(modbusData)
+	var coilData uint16
+	switch dataString {
+	case "0", "false", "False":
+		coilData = 0
+	case "1", "true", "True":
+		coilData = 0xFF00
+	default:
+		return fmt.Errorf("unknown coil data %v", coilData)
+	}
+
+	register := (*output).Data["address"]
+	registerInt, ok := register.(int)
+	if !ok {
+		return fmt.Errorf("Unable to convert (*output).Data[address] to uint16: %v", (*output).Data["address"])
+	}
+	registerUint16 := uint16(registerInt)
+
+	_, err = (*client).WriteSingleCoil(registerUint16, coilData)
+	return err
 }

--- a/pkg/devices/common.go
+++ b/pkg/devices/common.go
@@ -1,0 +1,76 @@
+package devices
+
+// This file contains common modbus device code.
+import (
+	"fmt"
+
+	"github.com/goburrow/modbus"
+	"github.com/mitchellh/mapstructure"
+	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/config"
+	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/utils"
+	"github.com/vapor-ware/synse-sdk/sdk"
+)
+
+// GetModbusClientAndConfig is common code to get the modbus configuration and client from the device configuration.
+func GetModbusClientAndConfig(device *sdk.Device) (modbusConfig *config.ModbusDeviceData, client *modbus.Client, err error) {
+
+	// Pull the modbus configuration out of the device Data fields.
+	var deviceData config.ModbusDeviceData
+	err = mapstructure.Decode(device.Data, &deviceData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create the modbus client from the configuration data.
+	cli, err := utils.NewClient(&deviceData)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &deviceData, &cli, nil
+}
+
+// GetOutput is a helper to get the first output for a device. Called by Write functions.
+func GetOutput(device *sdk.Device) (output *sdk.Output, err error) {
+
+	if device == nil {
+		return nil, fmt.Errorf("device is nil")
+	}
+	if device.Outputs == nil {
+		return nil, fmt.Errorf("device.Outputs is nil")
+	}
+
+	// Checking for one output for now. We need the register to write.
+	// We could support multiple outputs in the future by matching against
+	// info if we like.
+	length := len(device.Outputs)
+	if length == 0 {
+		return nil, fmt.Errorf("no device outputs")
+	}
+
+	if length > 1 {
+		return nil, fmt.Errorf("multiple device outputs unsupported")
+	}
+	return device.Outputs[0], nil
+}
+
+// UnpackReading is a wrapper for CastToType and MakeReading.
+func UnpackReading(output *sdk.Output, typeName string, rawReading []byte, failOnErr bool) (reading *sdk.Reading, err error) {
+
+	// Cast the raw reading value to the specified output type
+	data, err := utils.CastToType(typeName, rawReading)
+	if err != nil {
+		if failOnErr {
+			return nil, err
+		}
+		return nil, nil // No reading.
+	}
+
+	reading, err = output.MakeReading(data)
+	if err != nil {
+		// In this case we will not check the 'failOnError' flag because
+		// this isn't an issue with reading the device, its a configuration
+		// issue and the error should be noted.
+		return nil, err
+	}
+	return
+}

--- a/pkg/devices/holding_register.go
+++ b/pkg/devices/holding_register.go
@@ -1,18 +1,21 @@
 package devices
 
 import (
+	"fmt"
+	"strconv"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/mitchellh/mapstructure"
 	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/config"
-	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/utils"
 	"github.com/vapor-ware/synse-sdk/sdk"
 )
 
 // HoldingRegisterHandler is a handler which should be used for all devices/outputs
 // that read from/write to holding registers.
 var HoldingRegisterHandler = sdk.DeviceHandler{
-	Name: "holding_register",
-	Read: readHoldingRegister,
+	Name:  "holding_register",
+	Read:  readHoldingRegister,
+	Write: writeHoldingRegister,
 }
 
 // readHoldingRegister is the read function for the holding register device handler.
@@ -27,18 +30,12 @@ func readHoldingRegister(device *sdk.Device) ([]*sdk.Reading, error) {
 	//   }
 	log.Debugf("readHoldingRegister start: %+v", device)
 
-	var deviceData config.ModbusDeviceData
-	err := mapstructure.Decode(device.Data, &deviceData)
+	modbusConfig, client, err := GetModbusClientAndConfig(device)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := utils.NewClient(&deviceData)
-	if err != nil {
-		return nil, err
-	}
-
-	failOnErr := deviceData.FailOnError
+	failOnErr := (*modbusConfig).FailOnError
 	log.Debugf("fail on error: %v", failOnErr)
 
 	var readings []*sdk.Reading
@@ -68,7 +65,7 @@ func readHoldingRegister(device *sdk.Device) ([]*sdk.Reading, error) {
 			uint16(outputData.Address),
 			uint16(outputData.Width))
 
-		results, err := client.ReadHoldingRegisters(
+		results, err := (*client).ReadHoldingRegisters(
 			uint16(outputData.Address), uint16(outputData.Width))
 		if err != nil {
 			if failOnErr {
@@ -79,22 +76,9 @@ func readHoldingRegister(device *sdk.Device) ([]*sdk.Reading, error) {
 		}
 
 		log.Debugf("ReadHoldingRegisters: results: 0x%0x, len(results) 0x%0x", results, len(results))
-		// Cast the raw reading value to the specified output type
-		data, err := utils.CastToType(outputData.Type, results)
-		if err != nil {
-			if failOnErr {
-				return nil, err
-			}
-			log.Errorf("error casting reading data: %v, error %v", data, err)
-			continue
-		}
 
-		log.Debugf("holding register read result: %T, %v", data, data)
-		reading, err := output.MakeReading(data)
+		reading, err := UnpackReading(output, outputData.Type, results, failOnErr)
 		if err != nil {
-			// In this case we will not check the 'failOnError' flag because
-			// this isn't an issue with reading the device, its a configuration
-			// issue and the error should be noted.
 			return nil, err
 		}
 		readings = append(readings, reading)
@@ -102,4 +86,46 @@ func readHoldingRegister(device *sdk.Device) ([]*sdk.Reading, error) {
 
 	log.Debugf("readHoldingRegister end, readings: %+v", readings)
 	return readings, nil
+}
+
+// writeHoldingRegister is the write function for the holding register device handler.
+func writeHoldingRegister(device *sdk.Device, data *sdk.WriteData) (err error) {
+
+	if device == nil {
+		return fmt.Errorf("device is nil")
+	}
+	if data == nil {
+		return fmt.Errorf("data is nil")
+	}
+
+	_, client, err := GetModbusClientAndConfig(device)
+	if err != nil {
+		return err
+	}
+
+	// Pull out the data to send on the wire from data.Data.
+	modbusData := data.Data
+
+	output, err := GetOutput(device)
+	if err != nil {
+		return err
+	}
+
+	// Translate the data. This is currently a hex string.
+	dataString := string(modbusData)
+	register64, err := strconv.ParseUint(dataString, 16, 16)
+	if err != nil {
+		return fmt.Errorf("Unable to parse uint16 %v", dataString)
+	}
+	registerData := uint16(register64)
+
+	register := (*output).Data["address"]
+	registerInt, ok := register.(int)
+	if !ok {
+		return fmt.Errorf("Unable to convert (*output).Data[address] to uint16: %v", (*output).Data["address"])
+	}
+	registerUint16 := uint16(registerInt)
+
+	_, err = (*client).WriteSingleRegister(registerUint16, registerData)
+	return err
 }

--- a/pkg/devices/input_register.go
+++ b/pkg/devices/input_register.go
@@ -4,7 +4,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/mitchellh/mapstructure"
 	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/config"
-	"github.com/vapor-ware/synse-modbus-ip-plugin/pkg/utils"
 	"github.com/vapor-ware/synse-sdk/sdk"
 )
 
@@ -17,20 +16,13 @@ var InputRegisterHandler = sdk.DeviceHandler{
 
 // readInputRegister is the read function for the input register device handler.
 func readInputRegister(device *sdk.Device) ([]*sdk.Reading, error) {
-	var deviceData config.ModbusDeviceData
-	err := mapstructure.Decode(device.Data, &deviceData)
+
+	modbusConfig, client, err := GetModbusClientAndConfig(device)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := utils.NewClient(&deviceData)
-	if err != nil {
-		return nil, err
-	}
-
-	failOnErr := deviceData.FailOnError
-	log.Debugf("fail on error: %v", failOnErr)
-
+	failOnErr := (*modbusConfig).FailOnError
 	var readings []*sdk.Reading
 
 	// For each device instance, we will have various outputs defined.
@@ -52,7 +44,7 @@ func readInputRegister(device *sdk.Device) ([]*sdk.Reading, error) {
 		}
 
 		// Now use that to get the input register reading
-		results, err := client.ReadInputRegisters(uint16(outputData.Address), uint16(outputData.Width))
+		results, err := (*client).ReadInputRegisters(uint16(outputData.Address), uint16(outputData.Width))
 		if err != nil {
 			if failOnErr {
 				return nil, err
@@ -61,22 +53,8 @@ func readInputRegister(device *sdk.Device) ([]*sdk.Reading, error) {
 			continue
 		}
 
-		// Cast the raw reading value to the specified output type
-		data, err := utils.CastToType(outputData.Type, results)
+		reading, err := UnpackReading(output, outputData.Type, results, failOnErr)
 		if err != nil {
-			if failOnErr {
-				return nil, err
-			}
-			log.Errorf("error casting reading data: %v", err)
-			continue
-		}
-		log.Debugf("input register read result: %v", data)
-
-		reading, err := output.MakeReading(data)
-		if err != nil {
-			// In this case we will not check the 'failOnError' flag because
-			// this isn't an issue with reading the device, its a configuration
-			// issue and the error should be noted.
 			return nil, err
 		}
 		readings = append(readings, reading)


### PR DESCRIPTION
Sample curls: (There is a lag in there. We know about this.)
```
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ export SYNSE_IP=10.42.4.181
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
{
  "kind":"vem-plc.bms.start.switch",
  "data":[
    {
      "value":false,
      "timestamp":"2019-01-11T02:38:23.725901835Z",
      "unit":null,
      "type":"switch",
      "info":"BMS Start"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl -X POST -d '{"action":"","data":"1"}' http://${SYNSE_IP}:5000/synse/v2/write/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
[
  {
    "context":{
      "action":"",
      "data":"1"
    },
    "transaction":"bgs0399k2i8k3h3hvf4g"
  }
]
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl -X POST -d '{"action":"","data":"1"}' http://${SYNSE_IP}:5000/synse/v2/write/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
[
  {
    "context":{
      "action":"",
      "data":"1"
    },
    "transaction":"bgs03ahk2i8k3h3hvf50"
  }
]
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
{
  "kind":"vem-plc.bms.start.switch",
  "data":[
    {
      "value":false,
      "timestamp":"2019-01-11T02:38:32.203422321Z",
      "unit":null,
      "type":"switch",
      "info":"BMS Start"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
{
  "kind":"vem-plc.bms.start.switch",
  "data":[
    {
      "value":true,
      "timestamp":"2019-01-11T02:38:39.186670495Z",
      "unit":null,
      "type":"switch",
      "info":"BMS Start"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl -X POST -d '{"action":"","data":"false"}' http://${SYNSE_IP}:5000/synse/v2/write/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
[
  {
    "context":{
      "action":"",
      "data":"false"
    },
    "transaction":"bgs03ghk2i8k3h3hvf5g"
  }
]
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
{
  "kind":"vem-plc.bms.start.switch",
  "data":[
    {
      "value":true,
      "timestamp":"2019-01-11T02:38:59.294830242Z",
      "unit":null,
      "type":"switch",
      "info":"BMS Start"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
{
  "kind":"vem-plc.bms.start.switch",
  "data":[
    {
      "value":true,
      "timestamp":"2019-01-11T02:38:59.294830242Z",
      "unit":null,
      "type":"switch",
      "info":"BMS Start"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/1b6696e1c191b8dcbcab62cb7a4e334e
{
  "kind":"vem-plc.bms.start.switch",
  "data":[
    {
      "value":false,
      "timestamp":"2019-01-11T02:39:05.38271656Z",
      "unit":null,
      "type":"switch",
      "info":"BMS Start"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/173fc2e03fe8e387adaae71c46acdc80
{
  "kind":"vem-plc.fan",
  "data":[
    {
      "value":11,
      "timestamp":"2019-01-11T02:39:26.61542582Z",
      "unit":{
        "symbol":"%",
        "name":"percent"
      },
      "type":"fan_speed_percent",
      "info":"fan speed percentage"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl -X POST -d '{"action":"","data":"A"}' http://${SYNSE_IP}:5000/synse/v2/write/vem-rack/vem-plc/173fc2e03fe8e387adaae71c46acdc80
[
  {
    "context":{
      "action":"",
      "data":"A"
    },
    "transaction":"bgs03nhk2i8k3h3hvf60"
  }
]
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/173fc2e03fe8e387adaae71c46acdc80
{
  "kind":"vem-plc.fan",
  "data":[
    {
      "value":11,
      "timestamp":"2019-01-11T02:39:26.61542582Z",
      "unit":{
        "symbol":"%",
        "name":"percent"
      },
      "type":"fan_speed_percent",
      "info":"fan speed percentage"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$ curl http://${SYNSE_IP}:5000/synse/v2/read/vem-rack/vem-plc/173fc2e03fe8e387adaae71c46acdc80
{
  "kind":"vem-plc.fan",
  "data":[
    {
      "value":10,
      "timestamp":"2019-01-11T02:39:33.411242198Z",
      "unit":{
        "symbol":"%",
        "name":"percent"
      },
      "type":"fan_speed_percent",
      "info":"fan speed percentage"
    }
  ]
}
vapor@basx-vec1:~/src/vapor-charts/site/oregon/redmond$
```