### PR TITLE
EGauge / input register testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ HAS_GOX  := $(shell which gox)
 
 .PHONY: build
 build:  ## Build the plugin Go binary
-	go build -ldflags "${LDFLAGS}" -o build/plugin
+	go build -ldflags "${LDFLAGS}" -o build/plugin || exit
 
 .PHONY: ci
 ci:  ## Run CI checks locally (build, lint)
@@ -39,7 +39,7 @@ ci:  ## Run CI checks locally (build, lint)
 
 .PHONY: clean
 clean:  ## Remove temporary files
-	go clean -v
+	go clean -v || exit
 
 .PHONY: dep
 dep:  ## Ensure and prune dependencies
@@ -63,7 +63,7 @@ docker:  ## Build the docker image
 
 .PHONY: fmt
 fmt:  ## Run goimports on all go files
-	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file"; done
+	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file" || exit ; done
 
 .PHONY: github-tag
 github-tag:  ## Create and push a tag with the current plugin version
@@ -82,7 +82,7 @@ endif
 		--tests \
 		--sort=path --sort=line \
 		--aggregate \
-		--deadline=5m
+		--deadline=5m || exit
 
 .PHONY: setup
 setup:  ## Install the build and development dependencies and set up vendoring
@@ -96,7 +96,7 @@ endif
 
 .PHONY: test
 test:  ## Run project tests
-	go test -race -cover ./pkg/...
+	go test -race -cover ./pkg/... || exit
 
 .PHONY: version
 version:  ## Print the version of the plugin

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -57,6 +57,26 @@ var (
 		},
 	}
 
+	// Seconds in the output type for time readings in seconds.
+	Seconds = sdk.OutputType{
+		Name:      "seconds",
+		Precision: 6,
+		Unit: sdk.Unit{
+			Name:   "seconds",
+			Symbol: "s",
+		},
+	}
+
+	// Microseconds in the output type for time readings in microseconds.
+	Microseconds = sdk.OutputType{
+		Name:      "microseconds",
+		Precision: 6,
+		Unit: sdk.Unit{
+			Name:   "microseconds",
+			Symbol: "µs",
+		},
+	}
+
 	// FanSpeedPercent is the output type for the VEM PLC fan.
 	// This is a sliding window that is up to the PLC.
 	// We do not get absolute rpm.
@@ -145,6 +165,16 @@ var (
 		Unit: sdk.Unit{
 			Name:   "pounds per square inch",
 			Symbol: "psi",
+		},
+	}
+
+	// VoltSeconds is for flux.
+	VoltSeconds = sdk.OutputType{
+		Name:      "voltSeconds",
+		Precision: 3,
+		Unit: sdk.Unit{
+			Name:   "volt seconds",
+			Symbol: "Vs",
 		},
 	}
 )

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -18,6 +18,8 @@ func MakePlugin() *sdk.Plugin {
 		&outputs.Voltage,
 		&outputs.Frequency,
 		&outputs.SItoKWhPower,
+		&outputs.Seconds,
+		&outputs.Microseconds,
 		&outputs.FanSpeedPercent,
 		&outputs.FanSpeedPercentTenths,
 		&outputs.Temperature,
@@ -26,6 +28,7 @@ func MakePlugin() *sdk.Plugin {
 		&outputs.Coil,
 		&outputs.InWCThousanths,
 		&outputs.PsiTenths,
+		&outputs.VoltSeconds,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Add testing for the EGauge. We need 10 reads per device.
Add outputs for sensors we may or may not need. We can remove them if not required. We read the data from the EGauge anyway to reduce round trips.
Update Makefile to fail on failure.

This is not the cleanest checkin, but we need to verify that we can get data from the EGauge via bulk read before we get to the site and this does so.