### PR TITLE
updates for v3: bump sdk version, update output types, config update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ cover: test ## Run tests and open the coverage report
 	go tool cover -html=coverage.out
 
 .PHONY: dep
-dep:  ## Ensure and prune dependencies
-	dep ensure -v
+dep:  ## Verify and tidy gomod dependencies
+	go mod verify
+	go mod tidy
 
 .PHONY: deploy
 deploy:  ## Run a local deployment of the plugin with Synse Server

--- a/example/device/devices.yml
+++ b/example/device/devices.yml
@@ -7,7 +7,7 @@
 version: 3
 devices:
 - type: eg4115.power
-  metadata:
+  context:
     device: eGauge 4115 power meter
   handler: input_register
   data:

--- a/example/device/devices.yml
+++ b/example/device/devices.yml
@@ -8,7 +8,7 @@ version: 3
 devices:
 - type: eg4115.power
   context:
-    device: eGauge 4115 power meter
+    model: eGauge 4115
   handler: input_register
   data:
     host: 127.0.0.1

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
-	github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191105134802-f8ee5dba84f4
+	github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200118035017-928b1ad899c4
 )

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191105134802-f8ee5dba84f4 h1:6sdLKAOAlvfJiIed+C+SVRaJZF74EenNOZxFGzDvIbo=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191105134802-f8ee5dba84f4/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200118035017-928b1ad899c4 h1:cZ07W+IN8PKParZsxd81sP1NJccP8hnjsIF7lBgzLG4=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200118035017-928b1ad899c4/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4 h1:1ksn9Jm2+3xi8lQcm+a1/abs3wG2iGV7mTHRejCzqmY=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4/go.mod h1:66oRQ1KV/ZevAiiXbSUjRbx/h91xG/ArE/V39Jh872I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -4,74 +4,10 @@ import "github.com/vapor-ware/synse-sdk/sdk/output"
 
 var (
 
-	// SItoKWhPower is the output type that converts a power reading in SI
-	// (m2*kg/sec2(Joule)) to kilowatt hour (kWh). The conversion from kWh
-	// to SI unit is 2.60E+06, so the inverse is used to convert from SI
-	// to kWh 1/2.60E+06 ~= 2.77777778e-7
-	SItoKWhPower = output.Output{
-		Name:      "si-to-kwh.power",
-		Precision: 5,
-		Unit: &output.Unit{
-			Name:   "kilowatt hour",
-			Symbol: "kWh",
-		},
-	}
-
-	// Power is the output type for power (W) readings.
-	Power = output.Output{
-		Name:      "power",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name:   "watt",
-			Symbol: "W",
-		},
-	}
-
-	// Microseconds in the output type for time readings in microseconds.
-	Microseconds = output.Output{
-		Name:      "microseconds",
-		Precision: 6,
-		Unit: &output.Unit{
-			Name:   "microseconds",
-			Symbol: "µs",
-		},
-	}
-
-	// FanSpeedPercent is the output type for the VEM PLC fan.
-	// This is a sliding window that is up to the PLC.
-	// We do not get absolute rpm.
-	FanSpeedPercent = output.Output{
-		Name:      "fan_speed_percent",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name:   "percent",
-			Symbol: "%",
-		},
-	}
-
-	// FanSpeedPercentTenths is the output type for the VEM PLC fan in tenths.
-	FanSpeedPercentTenths = output.Output{
-		Name:      "fan_speed_percent_tenths",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name:   "percent",
-			Symbol: "%",
-		},
-	}
-
-	// Temperature is the output type for temperature readings.
-	Temperature = output.Output{
-		Name:      "temperature",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name:   "celsius",
-			Symbol: "C",
-		},
-	}
-
-	// FlowGpm is the output type for flow readings in gallons per minute. FUTURE: Metric / English.
-	FlowGpm = output.Output{
-		Name:      "flowGpm",
+	// GallonsPerMin is the output type for volumetric flow rate, measured in gallons per minute.
+	GallonsPerMin = output.Output{
+		Name:      "gallonsPerMin",
+		Type:      "flow",
 		Precision: 4,
 		Unit: &output.Unit{
 			Name:   "gallons per minute",
@@ -79,80 +15,15 @@ var (
 		},
 	}
 
-	// FlowGpmTenths is the output type for flow readings in tenths of gallons per minute. FUTURE: Metric / English.
-	FlowGpmTenths = output.Output{
-		Name:      "flowGpmTenths",
-		Precision: 4,
-		Unit: &output.Unit{
-			Name:   "gallons per minute",
-			Symbol: "gpm",
-		},
-	}
-
-	// Coil is the output type for a coil.
-	// VEM PLC coils are all active high, but this may vary with different devices.
-	// Perhaps Synse should abstract this away and report all coils as active high
-	// because Sysnse is a device level abstraction layer(?)
-	Coil = output.Output{
-		Name:      "switch",
-		Precision: 1,
-		Unit: &output.Unit{
-			Name:   "",
-			Symbol: "",
-		},
-	}
-
-	// InWCThousanths is the output type for pressure readings measured in thousanths of inches of water column..
-	InWCThousanths = output.Output{
-		Name:      "InWCThousanths",
-		Precision: 4,
+	// InchesWaterColumn is the output type for pressure readings, measures in inches of water
+	// column.
+	InchesWaterColumn = output.Output{
+		Name:      "inchesWaterColumn",
+		Type:      "pressure",
+		Precision: 8,
 		Unit: &output.Unit{
 			Name:   "inches of water column",
-			Symbol: "InWC",
+			Symbol: "inch wc",
 		},
-	}
-
-	// PsiTenths is the output type for pressure readings measured in tenths of pounds per square inch..
-	PsiTenths = output.Output{
-		Name:      "psiTenths",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name:   "pounds per square inch",
-			Symbol: "psi",
-		},
-	}
-
-	// VoltSeconds is for flux.
-	VoltSeconds = output.Output{
-		Name:      "voltSeconds",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name:   "volt seconds",
-			Symbol: "Vs",
-		},
-	}
-
-	// FIXME: not clear that this belongs here, as this is Vapor-specific and not
-	//   modbus related. We could define a position output in the SDK.
-
-	// CarouselPosition is for the position of the Carousel, result is Wedge Id
-	// facing the customer.
-	CarouselPosition = output.Output{
-		Name:      "carouselPosition",
-		Precision: 3,
-		Unit: &output.Unit{
-			Name: "position",
-		},
-	}
-
-	// StatusCode is the integer assosciated with a status response.
-	StatusCode = output.Output{
-		Name: "statusCode",
-	}
-
-	// StatusOutput is for an arbitrary string output which is meant to be the
-	// string translation for status code.
-	StatusOutput = output.Output{
-		Name: "status",
 	}
 )

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -16,21 +16,8 @@ func MakePlugin() *sdk.Plugin {
 
 	// Register output types
 	err = plugin.RegisterOutputs(
-		&outputs.Power,
-		&outputs.SItoKWhPower,
-		&outputs.Microseconds,
-		&outputs.FanSpeedPercent,
-		&outputs.FanSpeedPercentTenths,
-		&outputs.Temperature,
-		&outputs.FlowGpm,
-		&outputs.FlowGpmTenths,
-		&outputs.Coil,
-		&outputs.InWCThousanths,
-		&outputs.PsiTenths,
-		&outputs.VoltSeconds,
-		&outputs.CarouselPosition,
-		&outputs.StatusCode,
-		&outputs.StatusOutput,
+		&outputs.GallonsPerMin,
+		&outputs.InchesWaterColumn,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This PR:
- updates the output types, many not longer needed here since they are built-in to the SDK
- updates config issue (key metadata migrated to context)
- update sdk version -- ~this will need another update to sdk version when https://github.com/vapor-ware/synse-sdk/pull/446 lands~