### PR TITLE
do not fail all managers (hosts) if one fails to read

### DIFF
--- a/pkg/devices/coils.go
+++ b/pkg/devices/coils.go
@@ -53,14 +53,14 @@ func writeCoil(client modbus.Client, register uint16, data *sdk.WriteData) error
 	// by the modbus client.
 	coilData, err := getCoilData(data.Data)
 	if err != nil {
-		log.WithError(err).Error("failed to parse coil write data")
+		log.WithError(err).Error("[modbus] failed to parse coil write data")
 		return err
 	}
 
 	log.WithFields(log.Fields{
 		"address": register,
 		"data":    coilData,
-	}).Debug("writing to coil")
+	}).Debug("[modbus] writing to coil")
 	_, err = client.WriteSingleCoil(register, coilData)
 	return err
 }
@@ -70,13 +70,20 @@ func writeCoil(client modbus.Client, register uint16, data *sdk.WriteData) error
 // populated on plugin startup.
 func bulkReadCoils(managers []*ModbusDeviceManager) ([]*sdk.ReadContext, error) {
 	var readings []*sdk.ReadContext
+	var managersInErr []*ModbusDeviceManager
 
-	log.Debug("starting bulk read for coils")
 	for _, manager := range managers {
+		log.WithFields(log.Fields{
+			"host":     manager.Host,
+			"port":     manager.Port,
+			"slave id": manager.SlaveID,
+			"address":  manager.Address,
+		}).Debug("[modbus] starting bulk read for coils")
+
 		// Attempt to parse the manager's devices into register blocks for bulk read
 		// if they have not already been parsed.
 		if err := manager.ParseBlocks(); err != nil {
-			log.WithError(err).Error("failed to parse devices into read blocks")
+			log.WithError(err).Error("[modbus] failed to parse devices into read blocks")
 			return nil, err
 		}
 
@@ -84,13 +91,23 @@ func bulkReadCoils(managers []*ModbusDeviceManager) ([]*sdk.ReadContext, error) 
 			log.WithFields(log.Fields{
 				"startRegister": block.StartRegister,
 				"registerCount": block.RegisterCount,
-			}).Debug("reading coils for block")
+			}).Debug("[modbus] reading coils for block")
 			results, err := manager.Client.ReadCoils(block.StartRegister, block.RegisterCount)
 			if err != nil {
 				if manager.FailOnError {
-					return nil, err
+					// Since there may be multiple managers (e.g. modbus sources) configured,
+					// we don't want a failure to connect/read from one host to fail the read
+					// on another host. As such, we will skip over the manager on a read error
+					// and try the next one. If all managers fail to read, the bulk read will
+					// return an error.
+					managersInErr = append(managersInErr, manager)
+					log.WithFields(log.Fields{
+						"host": manager.Host,
+						"port": manager.Port,
+					}).Warn("[modbus] failed to read coils - skipping configured host")
+					break
 				}
-				log.WithError(err).Warning("ignoring error on read coils (failOnError is false)")
+				log.WithError(err).Warning("[modbus] ignoring error on read coils (failOnError is false)")
 				continue
 			}
 
@@ -100,7 +117,7 @@ func bulkReadCoils(managers []*ModbusDeviceManager) ([]*sdk.ReadContext, error) 
 			if len(results) > 0 {
 				results = results[0 : 2*block.RegisterCount] // Two bytes per register TODO double check this
 			}
-			log.WithField("results", results).Debug("got block read results for coils")
+			log.WithField("results", results).Debug("[modbus] got block read results for coils")
 			block.Results = results
 
 			// Parse the results from the bulk read. This will create the readings for
@@ -114,7 +131,7 @@ func bulkReadCoils(managers []*ModbusDeviceManager) ([]*sdk.ReadContext, error) 
 					if manager.FailOnError {
 						return nil, err
 					}
-					log.WithError(err).Warning("ignoring error on register unpack (failOnError is false)")
+					log.WithError(err).Warning("[modbus] ignoring error on register unpack (failOnError is false)")
 					continue
 				}
 
@@ -122,13 +139,22 @@ func bulkReadCoils(managers []*ModbusDeviceManager) ([]*sdk.ReadContext, error) 
 					"device": device.Device.GetID(),
 					"type":   reading.Type,
 					"value":  reading.Value,
-				}).Debug("created new reading from input register")
+				}).Debug("[modbus] created new reading from input register")
 				readCtx := sdk.NewReadContext(device.Device, []*output.Reading{reading})
 				readings = append(readings, readCtx)
 			}
 		}
 	}
 
+	if len(managersInErr) == len(managers) {
+		for _, manager := range managersInErr {
+			log.WithFields(log.Fields{
+				"host": manager.Host,
+				"port": manager.Port,
+			}).Error("[modbus] failed to read coils from host")
+		}
+		return nil, errors.New("failed to read coils from all configured hosts")
+	}
 	return readings, nil
 }
 


### PR DESCRIPTION
This PR:
- prevents bulk read failure in the event of an error returned from the modbus read. this could be due to a connectivity issue with one of the configured hosts and the failure to connect to one host should not prevent all other hosts from being read. If all hosts fail to read, the bulk read will fail.