### PR TITLE
bugfix: set correct path for build-time arguments for version info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,11 +9,11 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -w
-      - -X github.com/vapor-ware/synse-modbus-ip-plugin/vendor/github.com/vapor-ware/synse-sdk/sdk.BuildDate={{ .Date }}
-      - -X github.com/vapor-ware/synse-modbus-ip-plugin/vendor/github.com/vapor-ware/synse-sdk/sdk.GitCommit={{ .ShortCommit }}
-      - -X github.com/vapor-ware/synse-modbus-ip-plugin/vendor/github.com/vapor-ware/synse-sdk/sdk.GitTag={{ .Tag }}
-      - -X github.com/vapor-ware/synse-modbus-ip-plugin/vendor/github.com/vapor-ware/synse-sdk/sdk.GoVersion={{ .Env.GOVERSION }}
-      - -X github.com/vapor-ware/synse-modbus-ip-plugin/vendor/github.com/vapor-ware/synse-sdk/sdk.PluginVersion={{ .Version }}
+      - -X github.com/vapor-ware/synse-sdk/sdk.BuildDate={{ .Date }}
+      - -X github.com/vapor-ware/synse-sdk/sdk.GitCommit={{ .ShortCommit }}
+      - -X github.com/vapor-ware/synse-sdk/sdk.GitTag={{ .Tag }}
+      - -X github.com/vapor-ware/synse-sdk/sdk.GoVersion={{ .Env.GOVERSION }}
+      - -X github.com/vapor-ware/synse-sdk/sdk.PluginVersion={{ .Version }}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := modbus-ip
-PLUGIN_VERSION := 3.0.0-alpha.3
+PLUGIN_VERSION := 3.0.0-alpha.4
 IMAGE_NAME     := vaporio/modbus-ip-plugin
 BIN_NAME       := synse-modbus-ip-plugin
 
@@ -12,7 +12,7 @@ GIT_TAG        ?= $(shell git describe --tags 2> /dev/null || true)
 BUILD_DATE     := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
 GO_VERSION     := $(shell go version | awk '{ print $$3 }')
 
-PKG_CTX := github.com/vapor-ware/synse-modbus-ip-plugin/vendor/github.com/vapor-ware/synse-sdk/sdk
+PKG_CTX := github.com/vapor-ware/synse-sdk/sdk
 LDFLAGS := -w \
 	-X ${PKG_CTX}.BuildDate=${BUILD_DATE} \
 	-X ${PKG_CTX}.GitCommit=${GIT_COMMIT} \


### PR DESCRIPTION
This PR:
- fixes the path for setting build-time args for plugin version info
- bumps to 3.0.0-alpha.4

fixes: #42 