### PR TITLE
Type conversions for utf-8 strings.

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -80,6 +80,11 @@ func (b Bytes) Bool() bool {
 	return !(b[0] == 0)
 }
 
+// Utf8 converts the byte slice to a UTF-8 string.
+func (b Bytes) Utf8() string {
+	return string(b[:clen(b)])
+}
+
 // CastToType takes a typeName, which represents a well-known type, and
 // a byte slice and will attempt to cast the byte slice to the named type.
 func CastToType(typeName string, value []byte) (interface{}, error) {
@@ -130,7 +135,23 @@ func CastToType(typeName string, value []byte) (interface{}, error) {
 		// bool
 		return Bytes(value).Bool(), nil
 
+	case "t", "string", "utf8":
+		// utf-8 string
+		return Bytes(value).Utf8(), nil
+
 	default:
 		return nil, fmt.Errorf("unsupported output data type: %s", typeName)
 	}
+}
+
+// clen returns the index of the first NULL byte in n or len(n) if n contains no NULL byte.
+// This is from golang syscall, but it is not exported. BSD license.
+// https://golang.org/src/syscall/syscall_unix.go
+func clen(n []byte) int {
+	for i := 0; i < len(n); i++ {
+		if n[i] == 0 {
+			return i
+		}
+	}
+	return len(n)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -135,7 +135,7 @@ func CastToType(typeName string, value []byte) (interface{}, error) {
 		// bool
 		return Bytes(value).Bool(), nil
 
-	case "t", "string", "utf8":
+	case "t", "t16", "string", "utf8":
 		// utf-8 string
 		return Bytes(value).Utf8(), nil
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -282,7 +282,7 @@ func TestCastToType_Ok(t *testing.T) {
 			expectedLength: len("1805220218"),
 		},
 		{
-			typeName:       "t",
+			typeName:       "t16",
 			value:          []byte{0x34, 0x2e, 0x30, 0x2e, 0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 			expected:       "4.0.6",
 			expectedLength: len("4.0.6"),
@@ -294,6 +294,9 @@ func TestCastToType_Ok(t *testing.T) {
 			actual, err := CastToType(tt.typeName, tt.value)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
+			if tt.expectedLength != 0 {
+				assert.Equal(t, tt.expectedLength, len(actual.(string)))
+			}
 		})
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestCastToType_Ok(t *testing.T) {
 	var tests = []struct {
-		typeName string
-		value    []byte
-		expected interface{}
+		typeName       string
+		value          []byte
+		expected       interface{}
+		expectedLength int
 	}{
 		// unsigned 8-bit integer
 		{
@@ -259,6 +260,32 @@ func TestCastToType_Ok(t *testing.T) {
 			typeName: "boolean",
 			value:    []byte{0xff},
 			expected: true,
+		},
+
+		// utf-8 string
+		{
+			typeName:       "t",
+			value:          []byte{},
+			expected:       "",
+			expectedLength: 0,
+		},
+		{
+			typeName:       "string",
+			value:          []byte(nil),
+			expected:       "",
+			expectedLength: 0,
+		},
+		{
+			typeName:       "utf8",
+			value:          []byte{0x31, 0x38, 0x30, 0x35, 0x32, 0x32, 0x30, 0x32, 0x31, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expected:       "1805220218",
+			expectedLength: len("1805220218"),
+		},
+		{
+			typeName:       "t",
+			value:          []byte{0x34, 0x2e, 0x30, 0x2e, 0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expected:       "4.0.6",
+			expectedLength: len("4.0.6"),
 		},
 	}
 


### PR DESCRIPTION
This is part of the fix for adding serial number and firmware version for the EGauges which we can do when we migrate to v4.x firmware. (v3.6 supports it, but v3.4 does not) https://github.com/vapor-ware/edge-ops/issues/51