### PR TITLE
bugfix: reset client on read failure

### DIFF
--- a/pkg/devices/coils.go
+++ b/pkg/devices/coils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/goburrow/modbus"
 	log "github.com/sirupsen/logrus"
@@ -73,6 +74,9 @@ func bulkReadCoils(managers []*ModbusDeviceManager) ([]*sdk.ReadContext, error) 
 	var managersInErr []*ModbusDeviceManager
 
 	for _, manager := range managers {
+		// Synchronization for resetting client only once on read failure.
+		var resetOnce sync.Once
+
 		log.WithFields(log.Fields{
 			"host":     manager.Host,
 			"port":     manager.Port,
@@ -92,8 +96,19 @@ func bulkReadCoils(managers []*ModbusDeviceManager) ([]*sdk.ReadContext, error) 
 				"startRegister": block.StartRegister,
 				"registerCount": block.RegisterCount,
 			}).Debug("[modbus] reading coils for block")
+
 			results, err := manager.Client.ReadCoils(block.StartRegister, block.RegisterCount)
 			if err != nil {
+				// An error occurred while reading - this could be due to a connection which
+				// has been timed out, reset, or closed. To ensure we are not using a stale
+				// connection, reset the client for use on next read.
+				defer resetOnce.Do(func() {
+					log.WithFields(log.Fields{}).Info("[modbus] error on client read, will reset client connection")
+					if err := manager.ResetClient(); err != nil {
+						log.WithError(err).Error("[modbus] failed to reset client connection")
+					}
+				})
+
 				if manager.FailOnError {
 					// Since there may be multiple managers (e.g. modbus sources) configured,
 					// we don't want a failure to connect/read from one host to fail the read

--- a/pkg/devices/common.go
+++ b/pkg/devices/common.go
@@ -210,6 +210,18 @@ func (d *ModbusDeviceManager) ParseBlocks() error {
 	return nil
 }
 
+// ResetClient resets the client used by the manager. This is done when an error
+// occurs while reading from a device. This will ensure that a potentially closed
+// client connection will not be used next time around.
+func (d *ModbusDeviceManager) ResetClient() error {
+	c, err := newModbusClientFromManager(d)
+	if err != nil {
+		return err
+	}
+	d.Client = c
+	return nil
+}
+
 // ReadBlock holds the information for a single block of registers for a bulk read.
 type ReadBlock struct {
 	Devices       []*ModbusDevice

--- a/pkg/devices/common_test.go
+++ b/pkg/devices/common_test.go
@@ -507,6 +507,29 @@ func (suite *ModbusDeviceManagerTestSuite) TestParseBlocks_MultipleBlocks() {
 	suite.Equal(int32(2), d3.Device.SortIndex)
 }
 
+func (suite *ModbusDeviceManagerTestSuite) TestResetClient() {
+	manager := ModbusDeviceManager{
+		ModbusConfig: config.ModbusConfig{
+			Host:        "localhost",
+			Port:        6543,
+			FailOnError: true,
+		},
+	}
+	suite.Nil(manager.Client)
+
+	err := manager.ResetClient()
+	suite.NoError(err)
+
+	// hold a reference to the first client
+	firstClient := manager.Client
+
+	err = manager.ResetClient()
+	suite.NoError(err)
+
+	// verify the first client is different than the new one
+	suite.False(firstClient == manager.Client)
+}
+
 type ReadBlockTestSuite struct {
 	suite.Suite
 }

--- a/pkg/devices/input_register.go
+++ b/pkg/devices/input_register.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"errors"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk"
@@ -30,6 +31,9 @@ func bulkReadInputRegisters(managers []*ModbusDeviceManager) ([]*sdk.ReadContext
 	var managersInErr []*ModbusDeviceManager
 
 	for _, manager := range managers {
+		// Synchronization for resetting client only once on read failure.
+		var resetOnce sync.Once
+
 		log.WithFields(log.Fields{
 			"host":     manager.Host,
 			"port":     manager.Port,
@@ -49,8 +53,19 @@ func bulkReadInputRegisters(managers []*ModbusDeviceManager) ([]*sdk.ReadContext
 				"startRegister": block.StartRegister,
 				"registerCount": block.RegisterCount,
 			}).Debug("[modbus] reading input registers for block")
+
 			results, err := manager.Client.ReadInputRegisters(block.StartRegister, block.RegisterCount)
 			if err != nil {
+				// An error occurred while reading - this could be due to a connection which
+				// has been timed out, reset, or closed. To ensure we are not using a stale
+				// connection, reset the client for use on next read.
+				defer resetOnce.Do(func() {
+					log.WithFields(log.Fields{}).Info("[modbus] error on client read, will reset client connection")
+					if err := manager.ResetClient(); err != nil {
+						log.WithError(err).Error("[modbus] failed to reset client connection")
+					}
+				})
+
 				if manager.FailOnError {
 					// Since there may be multiple managers (e.g. modbus sources) configured,
 					// we don't want a failure to connect/read from one host to fail the read


### PR DESCRIPTION
This PR:
- should fix a bug where failure to read because of client reset/eof/connection close causes the manager client to become stale and unusable. it does so by creating a new client whenever there is a read failure.