### PR TITLE
Read only holding register.

### DIFF
--- a/pkg/devices/holding_register.go
+++ b/pkg/devices/holding_register.go
@@ -11,7 +11,10 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/output"
 )
 
+// Handler name definitions. These are used in the modbus device config
+// (under the "handler" key) to relate devices to a handler.
 const handlerHoldingRegister = "holding_register"
+const handlerReadOnlyHoldingRegister = "read_only_holding_register"
 
 // HoldingRegisterHandler is a device handler used to read from and write to modbus
 // holding registers.
@@ -42,6 +45,20 @@ var HoldingRegisterHandler = sdk.DeviceHandler{
 		}
 
 		return writeHoldingRegister(client, uint16(register), data)
+	},
+}
+
+// ReadOnlyHoldingRegisterHandler is a device handler used to read modbus
+// holding registers. No write method is available. This can be used to
+// restrict write access to holding registers
+var ReadOnlyHoldingRegisterHandler = sdk.DeviceHandler{
+	Name: handlerReadOnlyHoldingRegister,
+	BulkRead: func(devices []*sdk.Device) (contexts []*sdk.ReadContext, e error) {
+		managers, found := DeviceManagers[handlerReadOnlyHoldingRegister]
+		if !found {
+			return nil, errors.New("no device manager(s) found for read only holding register handler")
+		}
+		return bulkReadHoldingRegisters(managers)
 	},
 }
 

--- a/pkg/devices/holding_register_test.go
+++ b/pkg/devices/holding_register_test.go
@@ -316,3 +316,10 @@ func TestBulkReadHoldingRegisters_ErrorParseBlocks(t *testing.T) {
 //	assert.NoError(t, err)
 //	assert.Len(t, ctxs, 0)
 //}
+
+// Make sure that read and write functions are not implemented, just BulkRead.
+func TestReadOnlyHoldingRegister(t *testing.T) {
+	assert.Nil(t, ReadOnlyHoldingRegisterHandler.Read)
+	assert.NotNil(t, ReadOnlyHoldingRegisterHandler.BulkRead)
+	assert.Nil(t, ReadOnlyHoldingRegisterHandler.Write)
+}

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -27,6 +27,7 @@ func MakePlugin() *sdk.Plugin {
 	err = plugin.RegisterDeviceHandlers(
 		&devices.CoilsHandler,
 		&devices.HoldingRegisterHandler,
+		&devices.ReadOnlyHoldingRegisterHandler,
 		&devices.InputRegisterHandler,
 	)
 	if err != nil {


### PR DESCRIPTION
This is part of rotating the carousel.

The carousel exposes holding registers over modbus which are read/write. Only one register should ever be written to, the one that rotates the carousel. This PR will allow us to expose all carousel registers to synse as read only. Synse should not directly write to the carousel because Synse does not have the logic to perform door state checks (nor should it). That's vem-access.