### PR TITLE
ci: update jenkins config to use shared pipeline

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,78 +1,16 @@
 #!/usr/bin/env groovy
 
-pipeline {
+// Include this shared CI repository to load script helpers and libraries.
+library identifier: 'vapor@1.0.0-RC15', retriever: modernSCM([
+  $class: 'GitSCMSource',
+  remote: 'https://github.com/vapor-ware/ci-shared.git',
+  credentialsId: 'vio-bot-gh',
+])
 
-  agent {
-    label 'golang-alpha'
-  }
 
-  environment {
-    IMAGE_NAME = 'vaporio/modbus-ip-plugin'
-  }
-
-  stages {
-    stage('Checkout') {
-      steps {
-        checkout scm
-      }
-    }
-
-    stage('Checks') {
-      parallel {
-        stage('Lint') {
-          steps {
-            container('golang') {
-              sh 'golint -set_exit_status ./pkg/...'
-            }
-          }
-        }
-
-        stage('Test') {
-          steps {
-            container('golang') {
-              sh 'go test -cover -race ./pkg/...'
-            }
-          }
-        }
-
-        stage('Snapshot Build') {
-          steps {
-            container('golang') {
-              sh 'goreleaser release --debug --snapshot --skip-publish --rm-dist'
-            }
-          }
-        }
-      }
-    }
-
-    stage('Publish Latest') {
-      when {
-        branch 'master'
-      }
-      steps {
-        container('golang') {
-          withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-            sh 'docker push ${IMAGE_NAME}:latest'
-          }
-        }
-      }
-    }
-
-    stage('Tagged Release') {
-      when {
-        buildingTag()
-      }
-      environment {
-        GITHUB_TOKEN = credentials('vio-bot-gh-token')
-      }
-      steps {
-        container('golang') {
-          withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-            sh 'goreleaser release --debug --rm-dist'
-          }
-        }
-      }
-    }
-
-  }
-}
+golangPipeline([
+  'image': 'vaporio/modbus-ip-plugin',
+  'emulators': [
+    'modbus',
+  ]
+])

--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,11 @@ help:  ## Print usage information
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 .DEFAULT_GOAL := help
+
+
+# Jenkins CI Targets
+
+.PHONY: ci-integration-test
+
+ci-integration-test:
+	go test -v ./test/...


### PR DESCRIPTION
This PR:
- updates the jenkins config to use the ci-shared pipeline
- adds make target for integration testing using the modbus emulator in the repo

Note: this is blocked by https://github.com/vapor-ware/ci-shared/pull/61, as we will want to have that merged in and a new release cut so we can update the ci-shared ref in this PR to something stable.

fixes #68