### PR TITLE
Version 2.1.6. Remove Bytes output. Add Identity.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := modbus-ip
-PLUGIN_VERSION := 2.1.5
+PLUGIN_VERSION := 2.1.6
 IMAGE_NAME     := vaporio/modbus-ip-plugin
 BIN_NAME       := synse-modbus-ip-plugin
 

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -74,9 +74,10 @@ var (
 		},
 	}
 
-	// Bytes are arbitrary bytes.
-	Bytes = output.Output{
-		Name: "bytes",
-		Type: "bytes",
+	// Identity describes readings with identity outputs.
+	// Examples are model number and serial number.
+	Identity = output.Output{
+		Name: "identity",
+		Type: "identity",
 	}
 )

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -23,7 +23,7 @@ func MakePlugin() *sdk.Plugin {
 		&outputs.VoltAmp,
 		&outputs.VAR,
 		&outputs.WattHour,
-		&outputs.Bytes,
+		&outputs.Identity,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
I missed this output in the last commit. This won't affect anything externally, but makes more sense looking at the code. Hit this looking at busway config generator changes that need to happen.